### PR TITLE
Make some method to private because of danger initialization

### DIFF
--- a/lib/findbugs/plugin.rb
+++ b/lib/findbugs/plugin.rb
@@ -43,11 +43,17 @@ module Danger
     # It fails if `report_file` cannot be found inside current directory.
     # @return [void]
     #
-    def report
+
+    def report(inline_mode = true)
       return fail(GRADLEW_NOT_FOUND) unless gradlew_exists?
       exec_gradle_task
       return fail(REPORT_FILE_NOT_FOUND) unless report_file_exist?
-      send_inline_comment
+
+      if inline_mode
+        send_inline_comment
+      else
+        # TODO not implemented
+      end
     end
 
     # A getter for `gradle_module`, returning "app" if value is nil.
@@ -73,6 +79,8 @@ module Danger
     def target_files
       @target_files ||= (git.modified_files - git.deleted_files) + git.added_files
     end
+
+    private
 
     # Run gradle task
     # @return [void]

--- a/lib/findbugs/plugin.rb
+++ b/lib/findbugs/plugin.rb
@@ -74,13 +74,13 @@ module Danger
       @report_file ||= 'build/reports/findbugs_report.xml'
     end
 
+    private
+
     # A getter for current updated files
     # @return [Array[String]]
     def target_files
       @target_files ||= (git.modified_files - git.deleted_files) + git.added_files
     end
-
-    private
 
     # Run gradle task
     # @return [void]


### PR DESCRIPTION
danger初期化時に各プラグインのメソッドを暗黙的に呼び出しているようで、それのせいで初期化時にgradleなどが呼び出されてしまう不具合を修正しました。
呼び出し元↓
https://github.com/danger/danger/blob/master/lib/danger/danger_core/dangerfile.rb#L132
